### PR TITLE
Add ACCESS_CONTEXT_HUB and COMPANION_APPROVE_WIFI_CONNECTIONS permission for gmscore

### DIFF
--- a/system/etc/permissions/privapp-permissions-google-product.xml
+++ b/system/etc/permissions/privapp-permissions-google-product.xml
@@ -122,6 +122,8 @@ privileged Google applications in GMS devices.
     </privapp-permissions>
 
     <privapp-permissions package="com.google.android.gms">
+        <permission name="android.permission.COMPANION_APPROVE_WIFI_CONNECTIONS"/>
+        <permission name="android.permission.ACCESS_CONTEXT_HUB" />
         <permission name="android.permission.ACCESS_NETWORK_CONDITIONS"/>
         <permission name="android.permission.ACTIVITY_EMBEDDING"/>
         <permission name="android.permission.ALLOCATE_AGGRESSIVE"/>


### PR DESCRIPTION
After flashing MagiskGapps on my essential PH-1 (Android 11, linage os), it failed to boot
Logcat:
```
11-11 00:19:50.762 12398 12398 E System  : java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions whitelist: {com.google.android.gms (/system/priv-app/PrebuiltGmsCore): android.permission.ACCESS_CONTEXT_HUB, com.google.android.gms (/system/priv-app/PrebuiltGmsCore): android.permission.COMPANION_APPROVE_WIFI_CONNECTIONS}
11-11 00:19:50.762 12398 12398 E AndroidRuntime: java.lang.IllegalStateException: Signature|privileged permissions not in privapp-permissions whitelist: {com.google.android.gms (/system/priv-app/PrebuiltGmsCore): android.permission.ACCESS_CONTEXT_HUB, com.google.android.gms (/system/priv-app/PrebuiltGmsCore): android.permission.COMPANION_APPROVE_WIFI_CONNECTIONS}
11-11 00:19:55.765 12682 12682 W PackageManager: Privileged permission android.permission.ACCESS_CONTEXT_HUB for package com.google.android.gms (/system/priv-app/PrebuiltGmsCore) not in privapp-permissions whitelist
11-11 00:19:55.765 12682 12682 W PackageManager: Privileged permission android.permission.COMPANION_APPROVE_WIFI_CONNECTIONS for package com.google.android.gms (/system/priv-app/PrebuiltGmsCore) not in privapp-permissions whitelist
```
Then I refered https://gitlab.opengapps.org/opengapps/all/-/blob/master/etc/permissions/privapp-permissions-google.xml and added these two permission to gmscore, re-flashed this pack and it successfully boot.