### PR TITLE
fix: Add priv-app permission to gms - android.permission.INSTALL_LOCA…

### DIFF
--- a/system/etc/permissions/privapp-permissions-google-product.xml
+++ b/system/etc/permissions/privapp-permissions-google-product.xml
@@ -122,6 +122,7 @@ privileged Google applications in GMS devices.
     </privapp-permissions>
 
     <privapp-permissions package="com.google.android.gms">
+        <permission name="android.permission.INSTALL_LOCATION_TIME_ZONE_PROVIDER_SERVICE"/>
         <permission name="android.permission.COMPANION_APPROVE_WIFI_CONNECTIONS"/>
         <permission name="android.permission.ACCESS_CONTEXT_HUB" />
         <permission name="android.permission.ACCESS_NETWORK_CONDITIONS"/>


### PR DESCRIPTION
[r-stock e39ba80] fix: Add priv-app permission to gms - android.permission.INSTALL_LOCATION_TIME_ZONE_PROVIDER_SERVICE

This patch fixes a boot loop on Android 12 caused by gmscore lacking android.permission.INSTALL_LOCATION_TIME_ZONE_PROVIDER_SERVICE, like my previous patch